### PR TITLE
excluding bower and vendor js paths from jshint and minify

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -30,7 +30,7 @@ var options = {
 };
 
 gulp.task('jshint', function() {
-  gulp.src('ui/app/**/*.js')
+  gulp.src(['ui/app/**/*.js', '!ui/app/bower_components/**/*.js', '!ui/app/scripts/vendor/**/*.js'])
     .pipe(jshint())
     .pipe(jshint.reporter('default'));
 });
@@ -44,7 +44,7 @@ gulp.task('less', function() {
 
 // Concatenate & Minify JS
 gulp.task('scripts', function() {
-  return gulp.src('./ui/app/**/*.js')
+  return gulp.src(['./ui/app/**/*.js', '!ui/app/bower_components/**/*.js', '!ui/app/scripts/vendor/**/*.js'])
     .pipe(concat('all.js'))
     .pipe(gulp.dest('dist'))
     .pipe(rename('all.min.js'))


### PR DESCRIPTION
To prevent jshint and minifiying of third party libraries
