### PR TITLE
adds (optional) stateless-ness to the search controller

### DIFF
--- a/app/templates/_jshintrc
+++ b/app/templates/_jshintrc
@@ -5,7 +5,7 @@
   "eqeqeq": true,
   "immed": true,
   "indent": 2,
-  "latedef": true,
+  "latedef": "nofunc",
   "newcap": true,
   "quotmark": "single",
   "undef": true,
@@ -13,8 +13,11 @@
   "strict": true,
   "trailing": true,
   "globals": {
+    "console": false,
     "angular": false,
     "google": false,
-    "$": false
+    "$": false,
+    "_": false,
   }
 }
+

--- a/app/templates/bower.json
+++ b/app/templates/bower.json
@@ -14,7 +14,8 @@
     "ng-json-explorer": "*",
     "angular-bootstrap": "~0.11.0",
     "angular-highlightjs": "0.3.0",
-    "highlightjs": "8.0.0"
+    "highlightjs": "8.0.0",
+    "lodash": "~2.4.1"
   },
   "devDependencies": {
     "angular-mocks": "1.2.14",

--- a/app/templates/rest-api/ext/parse-query.xqy
+++ b/app/templates/rest-api/ext/parse-query.xqy
@@ -1,0 +1,25 @@
+xquery version "1.0-ml";
+
+module namespace ext = "http://marklogic.com/rest-api/resource/parse-query";
+
+import module namespace search = "http://marklogic.com/appservices/search" at "/MarkLogic/appservices/search/search.xqy";
+import module namespace sut = "http://marklogic.com/rest-api/lib/search-util" at "/MarkLogic/rest-api/lib/search-util.xqy";
+import module namespace csu = "http://marklogic.com/rest-api/config-query-util" at "/MarkLogic/rest-api/lib/config-query-util.xqy";
+
+declare namespace roxy = "http://marklogic.com/roxy";
+
+declare
+  %roxy:params("q=xs:string", "options=xs:string")
+function ext:get(
+  $context as map:map,
+  $params  as map:map
+) as document-node()*
+{
+  map:put($context, "output-types", "application/json"),
+  xdmp:set-response-code(200, "OK"),
+
+  let $q := map:get($params, "q")
+  let $options := sut:options($params)
+  let $query := search:parse($q, $options, "search:query")
+  return document { csu:xml-to-json($query) }
+};

--- a/app/templates/ui/app/app.js
+++ b/app/templates/ui/app/app.js
@@ -3,7 +3,8 @@ angular.module('sample', [
   'ngRoute', 'ngCkeditor', 'sample.user', 'sample.search', 'sample.common', 'sample.detail',
   'ui.bootstrap', 'gd.ui.jsonexplorer', 'sample.create'
 ])
-  .config(['$routeProvider', '$locationProvider', function ($routeProvider, $locationProvider) {
+  .constant('appConfig', { statelessSearch: false })
+  .config(['$routeProvider', '$locationProvider', 'appConfig', function ($routeProvider, $locationProvider, appConfig) {
 
     'use strict';
 
@@ -11,7 +12,9 @@ angular.module('sample', [
 
     $routeProvider
       .when('/', {
-        templateUrl: '/search/search.html'
+        templateUrl: '/search/search.html',
+        controller: 'SearchCtrl',
+        reloadOnSearch: !appConfig.statelessSearch
       })
       .when('/create', {
         templateUrl: '/create/create.html',

--- a/app/templates/ui/app/index.html
+++ b/app/templates/ui/app/index.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="styles/main.css">
     <!-- endbuild -->
   </head>
-  <body ng-app="sample" ng-controller="SearchCtrl">
+  <body ng-app="sample">
     <nav class="navbar navbar-default" role="navigation">
       <div class="navbar-header">
         <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
@@ -29,19 +29,11 @@
           <li><a href="/">Search</a></li>
           <li><a href="/create">Create</a></li>
         </ul>
-        <form class="navbar-form navbar-left" role="search">
-          <div class="form-group">
-            <input type="text" class="form-control" placeholder="Search" ng-model="model.text" autocomplete="off"
-              typeahead="suggestion for suggestion in getSuggestions($viewValue)" typeahead-loading="loadingSuggestions">
-            <span ng-show="loadingSuggestions" class="input-group-addon glyphicon glyphicon-refresh"></span>
-          </div>
-          <button type="submit" class="btn btn-default" ng-click="textSearch()">Submit</button>
-        </form>
-        <div ml-user username="model.user.name" password="model.user.password" authenticated="model.user.authenticated" login="login(username, password)" logout="logout()" loginerror="model.user.loginError"/>
+        <search-input class="navbar-form navbar-left"></search-input>
+        <ml-user></ml-user>
       </div><!-- /.navbar-collapse -->
     </nav>
     <!-- Add your site or application content here -->
-    <div ng-show="!model.user.authenticated">Please log in to see content</div>
     <div class="container" ng-view=""></div>
 
     <div id="footer">
@@ -50,6 +42,7 @@
 
     <!-- build:js scripts/plugins.js -->
     <script src="bower_components/jquery/jquery.js"></script>
+    <script src="bower_components/lodash/dist/lodash.min.js"></script>
     <script src="bower_components/angular/angular.js"></script>
     <script src="bower_components/angular-route/angular-route.js"></script>
     <script src="bower_components/angular-cookies/angular-cookies.js"></script>
@@ -78,6 +71,9 @@
     <script src="create/compile.js"></script>
     <script src="common/common.js"></script>
     <script src="common/services/mlrest.js"></script>
+    <script src="search/stateless-search.js"></script>
+    <script src="search/query-service.js"></script>
+    <script src="search/search-input-dir.js"></script>
     <!-- endbuild -->
   </body>
 </html>

--- a/app/templates/ui/app/search/facets-dir.html
+++ b/app/templates/ui/app/search/facets-dir.html
@@ -1,8 +1,10 @@
 <div class="facet-list">
   <div class="chiclets">
-    <div class="btn btn-primary" ng-repeat="chiclet in selected">
-      <span>{{chiclet.facet}}: {{chiclet.value}}</span>
-      <span class="glyphicon glyphicon-remove-circle icon-white" ng-click="clear(chiclet)"></span>
+    <div ng-repeat="(index, chiclet) in selected | object2Array">
+      <div ng-repeat="value in chiclet.values" class="btn btn-primary">
+        <span>{{ chiclet.__key }}: {{ value }}</span>
+        <span class="glyphicon glyphicon-remove-circle icon-white" ng-click="clear({facet: chiclet.__key, value: value})"></span>
+      </div>
     </div>
   </div>
   <div class="facet" ng-repeat="(index, facet) in facets | object2Array">

--- a/app/templates/ui/app/search/query-service.js
+++ b/app/templates/ui/app/search/query-service.js
@@ -1,0 +1,35 @@
+(function () {
+  'use strict';
+
+  angular.module('sample.search')
+    .factory('QueryService', QueryService);
+
+  function QueryService() {
+    var query = { q: '' },
+        callbacks = [];
+
+    function unsubscribe(idx) {
+      callbacks.splice(idx);
+    }
+
+    return {
+      get: function() {
+        return query;
+      },
+      set: function(q) {
+        query = q;
+        _.each(callbacks, function(callback) {
+          callback(query);
+        });
+      },
+      subscribe: function(callback) {
+        var idx = callbacks.length;
+        callbacks.push(callback);
+        return function() {
+          unsubscribe(idx);
+        };
+      }
+    };
+  }
+
+}());

--- a/app/templates/ui/app/search/search-input-dir.html
+++ b/app/templates/ui/app/search/search-input-dir.html
@@ -1,0 +1,16 @@
+<form ng-submit="search()" class="search form-inline" role="search">
+  <div class="form-group">
+    <input ng-model="query.q" type="text" class="form-control" placeholder="Search" autocomplete="off"
+      typeahead="suggestion for suggestion in suggest($viewValue)" typeahead-loading="loadingSuggestions">
+  </div>
+  <button ng-click="search()" type="submit" class="btn btn-default">
+    <i class="fa fa-search"></i>
+  </button>
+  <button ng-show="query.q" ng-click="clear()" type="reset" class="btn btn-default">
+    <i class="fa fa-times-circle"></i>
+  </button>
+  <span ng-show="loadingSuggestions">
+    <i class="fa fa-refresh fa-spin"></i>
+  </span>
+</form>
+

--- a/app/templates/ui/app/search/search-input-dir.js
+++ b/app/templates/ui/app/search/search-input-dir.js
@@ -1,0 +1,84 @@
+(function () {
+
+  'use strict';
+
+  angular.module('sample.search')
+    .directive('searchInput', searchInput)
+    .controller('SearchInputController', SearchInputController);
+
+  function searchInput() {
+    return {
+      restrict: 'E',
+      controller: 'SearchInputController',
+      scope: {},
+      templateUrl: '/search/search-input-dir.html',
+      link: function(scope, element, attrs) {
+        scope.query = { q: '' };
+      }
+    };
+  }
+
+  SearchInputController.$inject = ['$scope', '$location', '$route', 'MLRest', 'QueryService'];
+
+  function SearchInputController($scope, $location, $route, mlRest, queryService) {
+    var searchPath = getSearchRoute().originalPath,
+        unsubscribe = queryService.subscribe(function(query) {
+          $scope.query = query;
+        });
+
+    $scope.$on('$destroy', unsubscribe);
+
+    function getSearchRoute() {
+      var routes = _.where($route.routes, { controller: 'SearchCtrl' }),
+          route = {};
+
+      if (routes.length >= 1) {
+        route = routes[0];
+
+        if (routes.length > 1) {
+          console.log('multiple Search controller routes; choosing \'' + route.originalPath + '\'');
+        }
+
+      } else {
+        console.log(routes);
+        console.error('can\t find Search controller');
+        //TODO: get route from directive attribute?
+        // or throw new Error('can\t find Search controller');
+      }
+
+      return route;
+    }
+
+    function search() {
+      queryService.set( $scope.query );
+      $location.path( searchPath );
+    }
+
+    function clear() {
+      $scope.query = { q: '' };
+      search();
+    }
+
+    function suggest(val) {
+      //TODO: get from directive attribute?
+      var options = 'all';
+
+      return mlRest.callExtension('extsuggest', {
+        method: 'GET',
+        params: {
+          'rs:pqtxt': val,
+          'rs:options': options
+        }
+      }).then(function(res) {
+        return res.suggestions || [];
+      });
+    }
+
+    angular.extend($scope, {
+      search: search,
+      clear: clear,
+      suggest: suggest
+    });
+
+  }
+}());

--- a/app/templates/ui/app/search/search.html
+++ b/app/templates/ui/app/search/search.html
@@ -1,4 +1,5 @@
 <h1>Sample MarkLogic Application</h1>
+<div ng-show="!model.user.authenticated">Please log in to see content</div>
 <div class="row">
   <facets facet-list="model.search.facets" selected="model.selected" class="col-md-3"
           select="selectFacet(facet, value)" clear="clearFacet(facet, value)"></facets>

--- a/app/templates/ui/app/search/stateless-search.js
+++ b/app/templates/ui/app/search/stateless-search.js
@@ -1,0 +1,102 @@
+(function () {
+  'use strict';
+
+  angular.module('sample.common')
+    .factory('StatelessSearch', StatelessSearch);
+
+  StatelessSearch.$inject = ['MLRest', '$location', '$q'];
+
+  function StatelessSearch(mlRest, $location, $q) {
+
+    function newContext(searchContext, query) {
+      return new StatelessSearchContext(searchContext, query, mlRest, $location, $q);
+    }
+
+    return { new: newContext };
+  }
+
+  function StatelessSearchContext(searchContext, query, mlRest, $location, $q) {
+
+    function updateSearchQuery(response, d) {
+      var q = $location.search().q;
+
+      if ( q !== query.q ) {
+        searchContext.setText(q);
+      }
+
+      if ( response && response.query ) {
+        searchContext.clearAllFacets();
+        searchContext.parseStructuredQuery( response.query );
+      }
+
+      searchContext.search().then(function(data) {
+        d.resolve(data);
+      });
+    }
+
+    function getStructuredQuery(q) {
+      return mlRest.callExtension('parse-query', {
+        method: 'GET',
+        params: {
+          'rs:q': q,
+          'rs:options': searchContext.getQueryOptions()
+        }
+      });
+    }
+
+    function pathEquals(newUrl, oldUrl) {
+      // TODO: use $$urlUtils.urlResolve(), once it's available
+      // see: https://github.com/angular/angular.js/pull/3302
+      // from: https://stackoverflow.com/questions/21516891
+      function pathName(href) {
+        var x = document.createElement('a');
+        x.href = href;
+        return x.pathname;
+      }
+
+      return pathName(newUrl) === pathName(oldUrl);
+    }
+
+    function parseFacets(d) {
+      var facets = $location.search().facets;
+
+      if ( facets && facets !== query.facets ) {
+        getStructuredQuery(facets, searchContext).then(function(response) {
+          updateSearchQuery(response, d);
+        });
+      } else {
+        if (!facets) {
+          searchContext.clearAllFacets();
+        }
+        updateSearchQuery(null, d);
+      }
+
+      return d.promise;
+    }
+
+    function update() {
+      var d = $q.defer();
+      return parseFacets(d);
+    }
+
+    function locationChange(newUrl, oldUrl) {
+      var d = $q.defer(),
+          samePage = pathEquals(newUrl, oldUrl),
+          sameQuery = _.isEqual(query, $location.search());
+
+      if ( samePage && !sameQuery ) {
+        parseFacets(d);
+      } else {
+        d.reject();
+      }
+
+      return d.promise;
+    }
+
+    return {
+      update: update,
+      locationChange: locationChange
+    };
+  }
+
+}());

--- a/app/templates/ui/app/user/user-dir.html
+++ b/app/templates/ui/app/user/user-dir.html
@@ -1,10 +1,10 @@
 <div class="pull-right user">
   <!-- form to log in -->
-  <form class="navbar-form navbar-right" ng-hide="authenticated"
-    ng-submit="login(username, password)">
-    <div class="alert alert-danger" ng-show="loginerror" ng-cloak>Username and/or Password Incorrect</div>
+  <form class="navbar-form navbar-right" ng-hide="user.authenticated"
+    ng-submit="login(user.name, password)">
+    <div class="alert alert-danger" ng-show="user.loginError" ng-cloak>Username and/or Password Incorrect</div>
     <div class="form-group">
-      <input type="text" placeholder="Username" class="form-control" ng-model="username">
+      <input type="text" placeholder="Username" class="form-control" ng-model="user.name">
     </div>
     <div class="form-group">
       <input type="password" placeholder="Password" class="form-control" ng-model="password">
@@ -12,9 +12,9 @@
     <button type="submit" class="btn btn-success">Sign in</button>
   </form>
   <!-- display the logged in user -->
-  <div class="welcome" ng-show="authenticated">
+  <div class="welcome" ng-show="user.authenticated">
     <div class="navbar-collapse collapse">
-      <span class="glyphicon glyphicon-user"></span> {{username}} | <span class="profile-link"><a href="/profile">Account</a></span>
+      <span class="glyphicon glyphicon-user"></span> {{user.name}} | <span class="profile-link"><a href="/profile">Account</a></span>
 
       <button class="btn btn-default btn-xs" type="button" ng-click="logout()">Logout</button>
 

--- a/app/templates/ui/app/user/user-dir.js
+++ b/app/templates/ui/app/user/user-dir.js
@@ -2,60 +2,25 @@
 
   'use strict';
 
-  var module = angular.module('sample.user');
+  angular.module('sample.user')
+    .directive('mlUser', [function () {
+      return {
+        restrict: 'EA',
+        controller: 'UserController',
+        replace: true,
+        scope: {},
+        templateUrl: '/user/user-dir.html'
+      };
+    }])
+    .controller('UserController', ['$scope', 'User', function ($scope, user) {
+      angular.extend($scope, {
+        user: user,
+        login: user.login,
+        logout: function() {
+          user.logout();
+          $scope.password = '';
+        }
+      });
+    }]);
 
-  module.directive('mlUser', [function () {
-    return {
-      restrict: 'A',
-      controller: 'UserController',
-      replace: true,
-      scope: {
-        username: '=username',
-        password: '=password',
-        authenticated: '=authenticated',
-        login: '&login',
-        logout: '&logout',
-        loginerror: '=loginerror'
-      },
-      templateUrl: '/user/user-dir.html',
-      link: function($scope) {
-
-      }
-    };
-  }])
-  .controller('UserController', ['$scope', 'User', '$http', '$location', function ($scope, user, $http, $location) {
-    angular.extend($scope, {
-      login: function(username, password) {
-        $http.get(
-          '/user/login',
-          {
-            params: {
-              'username': username,
-              'password': password
-            }
-          }).then(function (result) {
-            user.authenticated = result.data.authenticated;
-            if (user.authenticated === true) {
-              user.loginError = false;
-              if (result.data.profile !== undefined) {
-                user.fullname = result.data.profile.fullname;
-                user.emails = result.data.profile.emails;
-              } else {
-                $location.path('/profile');
-              }
-            } else {
-              user.loginError = true;
-            }
-          });
-      },
-      logout: function() {
-        $http.get(
-          '/user/logout',
-          {}).then(function() {
-            user.init();
-          });
-      }
-
-    });
-  }]);
 }());

--- a/app/templates/ui/app/user/user-srv.js
+++ b/app/templates/ui/app/user/user-srv.js
@@ -2,42 +2,63 @@
   'use strict';
 
   angular.module('sample.user')
-  .factory('User', ['$http', function($http) {
-    var user = {};
+    .factory('User', ['$http', function($http) {
+      var user = {};
 
-    function updateUser(response) {
-      var data = response.data;
-      if (data.authenticated === true) {
-        user.name = data.username;
-        user.authenticated = true;
-        if (data.profile !== undefined) {
-          user.hasProfile = true;
+      init();
 
-          user.fullname = data.profile.fullname;
+      $http.get('/user/status', {}).then(updateUser);
 
-          if ($.isArray(data.profile.emails)) {
-            user.emails = data.profile.emails;
-          } else {
-            // wrap single value in array, needed for repeater
-            user.emails = [data.profile.emails];
+      function init() {
+        user.name = '';
+        user.password = '';
+        user.loginError = false;
+        user.authenticated = false;
+        user.hasProfile = false;
+        user.fullname = '';
+        user.emails = [];
+        return user;
+      }
+
+      function updateUser(response) {
+        var data = response.data;
+
+        user.authenticated = data.authenticated;
+
+        if ( user.authenticated ) {
+          user.name = data.username;
+
+          if ( data.profile ) {
+            user.hasProfile = true;
+            user.fullname = data.profile.fullname;
+
+            if ( _.isArray(data.profile.emails) ) {
+              user.emails = data.profile.emails;
+            } else {
+              // wrap single value in array, needed for repeater
+              user.emails = [data.profile.emails];
+            }
           }
         }
       }
-    }
 
-    $http.get('/user/status', {}).then(updateUser);
+      angular.extend(user, {
+        login: function(username, password) {
+          $http.get('/user/login', {
+            params: {
+              'username': username,
+              'password': password
+            }
+          }).then(function(reponse) {
+            updateUser(reponse);
+            user.loginError = !user.authenticated;
+          });
+        },
+        logout: function() {
+          $http.get('/user/logout').then(init);
+        }
+      });
 
-    user.init = function init() {
-      user.name = '';
-      user.password = '';
-      user.loginError = false;
-      user.authenticated = false;
-      user.hasProfile = false;
-      user.fullname = '';
-      user.emails = [];
       return user;
-    };
-
-    return user;
-  }]);
+    }]);
 }());


### PR DESCRIPTION
These changes add the option to serialize the search query as URL parameters.
This functionality supports deep-linking and the use of the forward and back
browser buttons.

The Search controller updates the URL parameters whenever a search is triggered.
Additionally, it watches the $locationChangeSuccess event, and updates the query
as the URL parameters change. This is done through the StatelessSearch service,
which uses the parse-query.xqy REST extension to convert string queries to
structured queries (when necessary).

Because the Search controller is modifying URL parameters, it can no longer be
always active. Therefore, I've rewritten the mlUser directive to not depend on
a parent scope, and implemented a searchInput directive, which uses a pub/sub-style
service to communicate query changes to the Search controller (events don't work,
since the controller might not be listening when a query is input).

/cc @dmcassel 
