### PR TITLE
added ml-lodlive to bower and included in index.html

### DIFF
--- a/app/templates/bower.json
+++ b/app/templates/bower.json
@@ -16,7 +16,8 @@
     "highlightjs": "8.0.0",
     "ml-utils": "withjam/ml-utils",
     "ml-search-ng": "~0.0.6",
-    "lodash": "~2.4.1"
+    "lodash": "~2.4.1",
+    "ml-lodlive": "latest"
   },
   "devDependencies": {
     "angular-mocks": "1.2.14",

--- a/app/templates/ui/app/index.html
+++ b/app/templates/ui/app/index.html
@@ -10,8 +10,9 @@
     <!-- build:css(.tmp) styles/all.css -->
     <link rel="stylesheet" href="/bower_components/ng-json-explorer/dist/angular-json-explorer.css">
     <link rel="stylesheet" href="/bower_components/highlightjs/styles/default.css">
-    <link rel="stylesheet" href="/styles/main.css">
+    <link rel="stylesheet" href="/bower_components/ml-lodlive/dist/ml-lodlive.all.css">
     <link rel="stylesheet" href="//js.arcgis.com/3.11/esri/css/esri.css">
+    <link rel="stylesheet" href="/styles/main.css">
     <!-- endbuild -->
   </head>
   <body ng-app="sample">
@@ -59,6 +60,7 @@
     <script src="/bower_components/ml-common-ng/dist/ml-common-ng.min.js"></script>
     <script src="/bower_components/ml-search-ng/dist/ml-search-ng.js"></script>
     <script src="/bower_components/ml-search-ng/dist/ml-search-ng-tpls.min.js"></script>
+    <script src="/bower_components/ml-lodlive/dist/ml-lodlive.complete.js"></script>
     <!-- endbuild -->
 
     <!-- build:js scripts/scripts.js -->


### PR DESCRIPTION
Now that ml-lodlive exists and is registered with Bower, Sid suggested it be included in the slush generator.  My updates simply add it to bower dependencies and include required resources in the index page.  Since it is designed to display triples data it didn't make sense to me to try to render anything without knowing what triples data it might be pointed at.  I also took the opportunity to make sure main.css appeared last in the list of css files so that it always wins out.