### PR TITLE
#194 Binary corruption fix in gulp replace

### DIFF
--- a/slushfile.js
+++ b/slushfile.js
@@ -382,7 +382,7 @@ gulp.task('init', ['checkForUpdates'], function (done) {
             }
 
           }))
-          .pipe(replace('@sample-app',answers.nameDashed))
+          .pipe(replace('@sample-app', answers.nameDashed, {skipBinary:true}))
           .pipe(gulp.dest('./')) // Relative to cwd
           .on('end', function () {
             done(); // Finished!


### PR DESCRIPTION
Fixes #194 

Quick google search found: https://github.com/lazd/gulp-replace/issues/6

So they added a binary option. I added the use of it here. Unfortunately not a good way to catch this error except by hand. Good eyes @jenbreese 