### PR TITLE
fixing the flow with wiredep. Turns out that running it when files ch…

### DIFF
--- a/app/templates/_bowerrc
+++ b/app/templates/_bowerrc
@@ -1,3 +1,6 @@
 {
-  "directory": "bower_components"
+  "directory": "bower_components",
+  "scripts": {
+    "postinstall": "gulp wiredep"
+  }
 }

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -163,7 +163,6 @@ gulp.task('inject', ['wiredep', 'styles', 'templatecache'], function() {
     .pipe(gulp.dest(config.client));
 });
 
-
 /**
  * Creates a sample local.json; can be used as model for dev.json and prod.json
  */
@@ -524,14 +523,14 @@ function isDevMode(env) {
 function getNodeOptions(env) {
   var envJson;
   var envFile = './' + env + '.json';
-    try {
-      envJson = require(envFile);
-    }
-    catch (e) {
-      envJson = {};
-      console.log('Couldn\'t find ' + envFile + '; you can create this file to override properties - ' +
-        '`gulp init-local` creates local.json which can be modified for other environments as well');
-    }
+  try {
+    envJson = require(envFile);
+  }
+  catch (e) {
+    envJson = {};
+    console.log('Couldn\'t find ' + envFile + '; you can create this file to override properties - ' +
+      '`gulp init-local` creates local.json which can be modified for other environments as well');
+  }
   var port = args['app-port'] || process.env.PORT || envJson['node-port'] || config.defaultPort;
   return {
     script: config.nodeServer,
@@ -569,9 +568,8 @@ function startBrowserSync(env, specRunner) {
   if (isDevMode(env)) {
     gulp.watch([config.less], ['styles'])
       .on('change', changeEvent);
-    gulp.watch([config.js], ['wiredep'])
-      .on('change', changeEvent);
-  } else {
+  }
+  else {
     gulp.watch([config.less, config.js, config.html], ['optimize', browserSync.reload])
       .on('change', changeEvent);
   }


### PR DESCRIPTION
…ange is bad. Browsersync automatically reloads the files. And running the extra wiredeps was actually removing newly added dependencies. The reason is that gulp wiredep seems to only inject files that were in the bower.json file when the process was started. So if you add new deps while running then they were getting constantly removed. Fixed now.