### PR TITLE
Fix #210 HighlightJS error

### DIFF
--- a/app/templates/bower.json
+++ b/app/templates/bower.json
@@ -10,13 +10,17 @@
     "angular-ui-tinymce": "~0.0.9",
     "bootstrap": "~3.3.5",
     "font-awesome": "~4.4.0",
-    "highlightjs": "~8.7.0",
     "jquery": "~2.1.4",
     "lodash": "~3.10.1",
     "ml-search-ng": "~0.2.0",
     "ml-utils": "withjam/ml-utils",
     "ng-json-explorer": "8c2a0f9104",
     "angular-mocks": "~1.4.4"
+  },
+  "overrides": {
+    "angular-highlightjs": {
+      "dependencies": {"angular" : ">1.0.8", "highlightjs":"~8.7.0"}
+    }
   },
   "devDependencies": {
     "angular-mocks": "~1.4.4",


### PR DESCRIPTION
#210 

Moved highlightjs above angular-highlightjs to hopefully ensure get correct order. I don't like this solution since it's easy to screw it back up. 

Could possibly not autoinject highlights.js script and move it outside of the normal js includes. Not sure what's ideal here..