### PR TITLE
Fixed #232: npm install had to run before bower install

### DIFF
--- a/app/templates/bower.json
+++ b/app/templates/bower.json
@@ -12,12 +12,12 @@
     "angular-x2js": "https://github.com/janmichaelyu/angular-x2js.git",
     "bootstrap": "~3.3.5",
     "font-awesome": "~4.4.0",
+    "highlightjs":"~8.7.0",
     "jquery": "~2.1.4",
     "lodash": "~3.10.1",
     "ml-search-ng": "~0.2.0",
     "ml-utils": "withjam/ml-utils",
     "ng-json-explorer": "8c2a0f9104",
-    "angular-mocks": "~1.4.3",
     "vkbeautify-wrapper": "*"
   },
   "overrides": {

--- a/slushfile.js
+++ b/slushfile.js
@@ -240,8 +240,13 @@ function configRoxy() {
 
 }
 
-gulp.task('default', ['init', 'generateSecret', 'configGulp'], function(done) {
-  gulp.src(['./bower.json', './package.json'])
+gulp.task('npmInstall', ['init', 'generateSecret', 'configGulp'], function(done) {
+  return gulp.src(['./package.json'])
+   .pipe(install());
+});
+
+gulp.task('default', ['npmInstall'], function(done) {
+  return gulp.src(['./bower.json'])
    .pipe(install());
 });
 


### PR DESCRIPTION
#232 

I also noticed highlightjs really needs to be listed explicitly for some reason. Bower install will otherwise barf..