### PR TITLE
#211 Turned off browsersync ui off

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -593,7 +593,8 @@ function startBrowserSync(env, specRunner) {
     logLevel: 'debug',
     logPrefix: 'gulp-patterns',
     notify: true,
-    reloadDelay: 0 //1000
+    reloadDelay: 0, //1000
+    ui: false
   } ;
   if (specRunner) {
     options.startPath = config.specRunnerFile;


### PR DESCRIPTION
Fixes #211 - removes ui feature of browsersync but easy to reenable.

If someone can make a relevant wiki edit on the troubleshooting/possible issues page when they merge this that would be great.