### PR TITLE
Hide 'Edit' and 'Delete' when `disallowUpdates: true`

### DIFF
--- a/app/templates/ui/app/detail/detail.controller.js
+++ b/app/templates/ui/app/detail/detail.controller.js
@@ -4,8 +4,9 @@
   angular.module('app.detail')
   .controller('DetailCtrl', DetailCtrl);
 
-  DetailCtrl.$inject = ['doc', '$stateParams','MLRest', 'ngToast','$state'];
-  function DetailCtrl(doc, $stateParams, MLRest, toast, $state) {
+  DetailCtrl.$inject = ['doc', '$stateParams','MLRest', 'ngToast',
+                        '$state','$scope','userService'];
+  function DetailCtrl(doc, $stateParams, MLRest, toast, $state, $scope, userService) {
     var ctrl = this;
 
     var uri = $stateParams.uri;
@@ -40,12 +41,6 @@
       ctrl.json = {'Error' : 'Error occured determining document type.'};
     }
 
-    angular.extend(ctrl, {
-      doc : doc.data,
-      uri : uri,
-      delete: deleteFunc
-    });
-
     function deleteFunc() {
       MLRest.deleteDocument (uri).then(function(response) {
         // create a toast with settings:
@@ -62,5 +57,15 @@
       });
     }
 
+    angular.extend(ctrl, {
+      doc : doc.data,
+      uri : uri,
+      currentUser: null,
+      delete: deleteFunc
+    });
+
+    $scope.$watch(userService.currentUser, function(newValue) {
+      ctrl.currentUser = newValue;
+    });
   }
 }());

--- a/app/templates/ui/app/detail/detail.controller.spec.js
+++ b/app/templates/ui/app/detail/detail.controller.spec.js
@@ -9,7 +9,7 @@
 
     beforeEach(function() {
       bard.appModule('app.detail');
-      bard.inject('$controller', '$rootScope', 'MLRest', '$q');
+      bard.inject('$controller', '$rootScope', 'MLRest', '$q', 'userService');
 
       bard.mockService(MLRest, {
         deleteDocument: $q.when('/?uri=blah')
@@ -25,7 +25,7 @@
           name: 'hi'
         }
       };
-      controller = $controller('DetailCtrl', { doc: doc });
+      controller = $controller('DetailCtrl', { doc: doc, $scope: $rootScope.$new() });
       $rootScope.$apply();
     });
 

--- a/app/templates/ui/app/detail/detail.html
+++ b/app/templates/ui/app/detail/detail.html
@@ -26,8 +26,11 @@
   <div class="col-sm-4">
     <div id="buttons-detail">
       <button class="btn btn-default" ui-sref="root.search">Search</button>
-      <button class="btn btn-primary" ui-sref="root.edit({uri: ctrl.uri})">Edit</button>
       <button class="btn btn-primary"
+              ng-show="ctrl.currentUser && !ctrl.currentUser.disallowUpdates" 
+              ui-sref="root.edit({uri: ctrl.uri})">Edit</button>
+      <button class="btn btn-primary"
+              ng-show="ctrl.currentUser && !ctrl.currentUser.disallowUpdates" 
               mwl-confirm
               title="This will permanently delete {{ctrl.uri}}, are you sure?"
               confirm-text="Yes"

--- a/app/templates/ui/app/detail/detail.module.js
+++ b/app/templates/ui/app/detail/detail.module.js
@@ -3,6 +3,7 @@
 
   angular.module('app.detail', [
     'app.similar',
+    'app.user',
     'ui.router',
     'ml.common', // Using MLRest for delete
     'ngToast', // Showing toast on delete

--- a/app/themes/map/ui/app/detail/detail.controller.js
+++ b/app/themes/map/ui/app/detail/detail.controller.js
@@ -5,9 +5,9 @@
   .controller('DetailCtrl', DetailCtrl);
 
   DetailCtrl.$inject = ['doc', '$stateParams', 'MLUiGmapManager','MLRest',
-    'ngToast','$state'];
+    'ngToast','$state','$scope','userService'];
 
-  function DetailCtrl(doc, $stateParams, mlMapManager, MLRest, toast, $state) {
+  function DetailCtrl(doc, $stateParams, mlMapManager, MLRest, toast, $state, $scope, userService) {
     var ctrl = this;
 
     var uri = $stateParams.uri;
@@ -60,12 +60,6 @@
       mlMapManager.center = { latitude: latitude, longitude: longitude };
     };
 
-    angular.extend(ctrl, {
-      doc : doc.data,
-      uri : uri,
-      delete: deleteFunc
-    });
-
     if (ctrl.type === 'json' || ctrl.type === 'xml') {
       //note that this should be matched with the exact data
 
@@ -89,5 +83,15 @@
       });
     }
 
+    angular.extend(ctrl, {
+      doc : doc.data,
+      uri : uri,
+      currentUser: null,
+      delete: deleteFunc
+    });
+
+    $scope.$watch(userService.currentUser, function(newValue) {
+      ctrl.currentUser = newValue;
+    });
   }
 }());

--- a/app/themes/map/ui/app/detail/detail.controller.spec.js
+++ b/app/themes/map/ui/app/detail/detail.controller.spec.js
@@ -9,7 +9,8 @@
 
     beforeEach(function() {
       bard.appModule('app.detail');
-      bard.inject('$controller', '$rootScope', 'MLUiGmapManager', 'uiGmapGoogleMapApi');
+      bard.inject('$controller', '$rootScope', 'userService',
+                  'MLUiGmapManager', 'uiGmapGoogleMapApi');
 
       // stub the document
       var headers = function() {
@@ -24,7 +25,8 @@
           }
         }
       };
-      controller = $controller('DetailCtrl', { doc: doc });
+      controller = $controller('DetailCtrl',
+                               { doc: doc, $scope: $rootScope.$new() });
       $rootScope.$apply();
     });
 

--- a/app/themes/map/ui/app/detail/detail.html
+++ b/app/themes/map/ui/app/detail/detail.html
@@ -1,8 +1,11 @@
 <div class="row detail">
   <div class="col-sm-12" id="buttons-detail">
     <button class="btn btn-default" ui-sref="root.search">Search</button>
-    <button class="btn btn-primary" ui-sref="root.edit({uri: ctrl.uri})">Edit</button>
     <button class="btn btn-primary"
+            ng-show="ctrl.currentUser && !ctrl.currentUser.disallowUpdates" 
+            ui-sref="root.edit({uri: ctrl.uri})">Edit</button>
+    <button class="btn btn-primary"
+            ng-show="ctrl.currentUser && !ctrl.currentUser.disallowUpdates" 
             mwl-confirm
             title="This will permanently delete {{ctrl.uri}}, are you sure?"
             confirm-text="Yes"

--- a/app/themes/map/ui/app/detail/detail.module.js
+++ b/app/themes/map/ui/app/detail/detail.module.js
@@ -3,6 +3,7 @@
 
   angular.module('app.detail', [
     'app.similar',
+    'app.user',
     'ui.router',
     'app.root',
     'uiGmapgoogle-maps',


### PR DESCRIPTION
Previously, the buttons still appeared, but resulted in a blank page for 'Edit' and an unhandled server error for 'Delete'.

Note that this does not remove the 'Edit' and 'Delete' buttons for a Guest (just as the Create button is not removed for a guest) - this would be nice, but there is currently no different in `ctrl.currentUser` between a logged-in app-user and a guest, so no way I can see to check in the template.

This requires adding the userService and $scope as additional dependencies in the generated detail controller.

It seems that only the map theme has an override for the detail controller. I made the changes there as well.

I tested this against the default template and the map theme.