### PR TITLE
fixing the footer logo for bug #382

### DIFF
--- a/app/themes/dashboard/ui/styles/theme.less
+++ b/app/themes/dashboard/ui/styles/theme.less
@@ -61,3 +61,7 @@ form.ml-input.ml-search {
 .create form {
   padding-bottom: 50px;
 }
+
+.powered {
+  background: transparent url(/images/MarkLogic-Powered-By.png) no-repeat scroll right;
+}


### PR DESCRIPTION
This is a fix for the footer logo that is being covered by the left col. It is half uncovered when the col is collapsed. 