### PR TITLE
Do not add padding to .row in the dashboard theme

### DIFF
--- a/app/themes/dashboard/ui/app/root/root.html
+++ b/app/themes/dashboard/ui/app/root/root.html
@@ -61,7 +61,7 @@
 
   <div class="content-wrapper" style="min-height:800px">
     <message-board msg="rootCtrl.messageBoardService.message()"></message-board>
-    <div ng-hide="rootCtrl.messageBoardService.message()">
+    <div ng-hide="rootCtrl.messageBoardService.message()" class="content">
       <ui-view></ui-view>
     </div>
   </div>

--- a/app/themes/dashboard/ui/styles/theme.less
+++ b/app/themes/dashboard/ui/styles/theme.less
@@ -16,10 +16,6 @@ a {
   cursor: hand;
 }
 
-.row {
-  padding: 0 15px;
-}
-
 h1 {
   margin-top: 0px;
   padding: 30px 15px 15px 15px;


### PR DESCRIPTION
In Bootstrap, .row has no padding (and in fact has a negative margin)
to allow for nested columns. (See http://getbootstrap.com/css/#grid-nesting) 
In the Dashboard theme, we are adding additional padding to .row, which breaks that system.

I just ran into this setting on a
dashboard-style demo, where I could not figure out why my nested columns
keep getting more and more indented.

I believe that this line of css was added to fix the search screen for
the dashboard theme. But a better fix is to use the "content" class
provided by AdminLTE. This is what I have done on my own demo, and it is
working well. It is also what the AdminLTE site does (though it is oddly
undocumented): https://almsaeedstudio.com/themes/AdminLTE/index2.html