### PR TITLE
getAuthenticatedStatus needs to always return promise

### DIFF
--- a/app/templates/ui/app/login/login.service.js
+++ b/app/templates/ui/app/login/login.service.js
@@ -175,21 +175,12 @@
       }
 
       if (routeIsProtected(next.name)) {
-        var auth = service.getAuthenticatedStatus();
-
-        if (angular.isFunction(auth.then)) {
-          auth.then(function() {
-            if (!service.isAuthenticated()) {
-              //this does NOT block requests in a timely fashion...
-              blockRoute(event, next, nextParams);
-            }
-          });
-        }
-        else {
-          if (!auth) {
+        service.getAuthenticatedStatus().then(function() {
+          if (!service.isAuthenticated()) {
+            //this does NOT block requests in a timely fashion...
             blockRoute(event, next, nextParams);
           }
-        }
+        });
 
       }
     });

--- a/app/templates/ui/app/login/login.service.js
+++ b/app/templates/ui/app/login/login.service.js
@@ -38,7 +38,7 @@
 
     function getAuthenticatedStatus() {
       if (_isAuthenticated !== undefined) {
-        return _isAuthenticated;
+        return $q.resolve(_isAuthenticated);
       }
 
       return $http.get('/api/user/status', {}).then(function(response) {
@@ -120,6 +120,8 @@
             'params': JSON.stringify((_toStateParams || $stateParams))
           }).then(function() {
             d.reject();
+          }, function(error) {
+            throw error;
           });
       }
       return d.promise;

--- a/app/templates/ui/app/user/user.service.js
+++ b/app/templates/ui/app/user/user.service.js
@@ -4,8 +4,8 @@
   angular.module('app.user')
     .factory('userService', UserService);
 
-  UserService.$inject = ['$rootScope', 'loginService'];
-  function UserService($rootScope, loginService) {
+  UserService.$inject = ['$rootScope', '$q', 'loginService'];
+  function UserService($rootScope, $q, loginService) {
     var _currentUser = null;
 
     function currentUser() {
@@ -14,7 +14,7 @@
 
     function getUser() {
       if (_currentUser) {
-        return _currentUser;
+        return $q.resolve(_currentUser);
       }
 
       return loginService.getAuthenticatedStatus().then(currentUser);


### PR DESCRIPTION
If the _isAuthenticated memo was already set, it was returned a bald
value, without wrapping in a promise

Also, I found and threw the error that wasn't showing up - which would
have helped debug this issue.

Fixes #480