### PR TITLE
Optimize the similar extension

### DIFF
--- a/app/templates/rest-api/ext/extsimilar.xqy
+++ b/app/templates/rest-api/ext/extsimilar.xqy
@@ -43,12 +43,15 @@ function ext:post(
   let $content :=
     if (exists($uri)) then
       json:to-array(
-        (
-          for $doc in cts:search(collection(), cts:and-query(($collection-q,cts:similar-query(doc($uri)))))
-          let $similar-uri := xdmp:node-uri($doc)
-          where $similar-uri != $uri
-          return $similar-uri
-        )[1 to $limit]
+        cts:uris(
+          (),
+          ("limit="||$limit),
+          cts:and-query((
+            cts:not-query(cts:document-query($uri)),
+            $collection-q,
+            cts:similar-query(doc($uri))
+          ))
+        )
       )
     else json:array()
   let $response := json:object()


### PR DESCRIPTION
Have had the performance of the similar REST extension bite me in the past since it does a for loop over all the similar documents returned. Enhanced it to resolve the URIs straight from the indexes.